### PR TITLE
Fix employee transfer file copy

### DIFF
--- a/AssetManagement.Repositories/AppRepository.cs
+++ b/AssetManagement.Repositories/AppRepository.cs
@@ -2230,6 +2230,7 @@ namespace AssetManagement.Repositories
                             string BankPassBook = ReplaceFirstWordAfterHyphen(fileMapping.BankPassbookFile, data.NewEmployeeId);
                             string Cert = ReplaceFirstWordAfterHyphen(fileMapping.CertificateFile, data.NewEmployeeId);
                             string Profile = ReplaceFirstWordAfterHyphen(fileMapping.ProfilePhotoFile, data.NewEmployeeId);
+                            string Resume = ReplaceFirstWordAfterHyphen(fileMapping.ResumeFile, data.NewEmployeeId);
 
                             // Copy the files on the file system
                             CopyFile(fileMapping.AadhaarFile, Aadhaar);
@@ -2237,6 +2238,7 @@ namespace AssetManagement.Repositories
                             CopyFile(fileMapping.BankPassbookFile, BankPassBook);
                             CopyFile(fileMapping.CertificateFile, Cert);
                             CopyFile(fileMapping.ProfilePhotoFile, Profile);
+                            CopyFile(fileMapping.ResumeFile, Resume);
 
                             var newFileMapping = new EmployeeFilesMapping
                             {
@@ -2245,7 +2247,8 @@ namespace AssetManagement.Repositories
                                 PanFile = Pan,
                                 BankPassbookFile = BankPassBook,
                                 CertificateFile = Cert,
-                                ProfilePhotoFile = Profile
+                                ProfilePhotoFile = Profile,
+                                ResumeFile = Resume
                             };
 
                             AppDbCxt.EmployeeFilesMapping.Add(newFileMapping);


### PR DESCRIPTION
## Summary
- ensure EmployeeTransfer also copies ResumeFile and replicates it for the new employee

## Testing
- `dotnet build --no-restore -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6863c0ba93ac83228f2a84a0ffc5576d