### PR TITLE
Fix PageDialog parameter reference

### DIFF
--- a/AssetManagement/Client/Pages/AppPages/Employees/EmployeeDataConfig.razor
+++ b/AssetManagement/Client/Pages/AppPages/Employees/EmployeeDataConfig.razor
@@ -814,11 +814,11 @@
                     }
                 }
             </Dailog>
-            <PageDialog Title="Add Skills" Show="AddSkill" ClosePageDialog="ClosePopUp">
+            <PageDialog Title="Add Skills" Show="AddSkill" OnCloseDialog="ClosePopUp">
                 <AddSkillComponent />
             </PageDialog>
 
-            <PageDialog Title="Add Designtions" Show="AddDesigntions" ClosePageDialog="ClosePopUp">
+            <PageDialog Title="Add Designtions" Show="AddDesigntions" OnCloseDialog="ClosePopUp">
                 <AddDesignationComponent OnSaveDesignation="HandleSaveDesignation" />
             </PageDialog>
 


### PR DESCRIPTION
## Summary
- fix parameter name for PageDialog usage in employee data config

## Testing
- `dotnet build AssetManagement.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68640269bca88322a22ac4fb34fc1032