### PR TITLE
Fix DropdownSelect nullable int bug

### DIFF
--- a/AssetManagement/Client/Pages/AppPages/Allocation/AllocationConfig.razor
+++ b/AssetManagement/Client/Pages/AppPages/Allocation/AllocationConfig.razor
@@ -125,13 +125,13 @@ else
                         <label class="col-form-label bold-font">Asset Details</label>
                         <div class="card" style="background:darkcyan">
                             <div class="card-body">
-                                @if (model.AssetId == 0)
+                                @if (!model.AssetId.HasValue || model.AssetId == 0)
                                 {
                                     <p class="mb-0 text-muted">No Asset Selected!</p>
                                 }
                                 else
                                 {
-                                    <p class="mb-0">@asset.Where(a => a.Id == model.AssetId).Select(d => d.Description).FirstOrDefault()</p>
+                                    <p class="mb-0">@asset.FirstOrDefault(a => a.Id == model.AssetId)?.Description</p>
                                 }
                             </div>
                         </div>

--- a/AssetManagement/Client/Shared/Component/DropdownSelect.razor.cs
+++ b/AssetManagement/Client/Shared/Component/DropdownSelect.razor.cs
@@ -59,7 +59,7 @@ public partial class DropdownSelect<TValue> : InputSelect<TValue>, IAsyncDisposa
             int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue);
             CurrentValue = (TValue)(object)parsedValue;
         }
-        else if (typeof(TValue) == typeof(int))
+        else if (typeof(TValue) == typeof(int?))
         {
             if (value == null)
             {


### PR DESCRIPTION
## Summary
- fix DropdownSelect generic check for nullable ints
- show 'No Asset Selected' message when AssetId is null

## Testing
- `dotnet build AssetManagement.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68664e92460883229c5da880618b4d85