### PR TITLE
Fix skills selection binding in ViewReport

### DIFF
--- a/AssetManagement/Client/Pages/AppPages/Report/ViewReport.razor
+++ b/AssetManagement/Client/Pages/AppPages/Report/ViewReport.razor
@@ -101,7 +101,7 @@
                         <div class="form-group row" style="padding:4px">
                             <div class="col-md-4">
                                 <HxMultiSelect TItem="string" TValue="string" Data="SkillOptions"
-                                               Value="selectedSkills"
+                                               Value="@selectedSkills"
                                                ValueChanged="OnSkillsChanged"
                                                ValueExpression="@(() => selectedSkills)"
                                                TextSelector="@(s => s)" ValueSelector="@(s => s)"


### PR DESCRIPTION
## Summary
- bind HxMultiSelect Value to `selectedSkills` variable with `@`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6868925518688322bfc4f2b219f60425