### PR TITLE
Fix header and breadcrumb positioning

### DIFF
--- a/AssetManagement/Client/wwwroot/assets/css/app.css
+++ b/AssetManagement/Client/wwwroot/assets/css/app.css
@@ -150,7 +150,8 @@ main {
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    /* Allow sticky elements like the header and breadcrumb to remain fixed */
+    overflow: visible;
 }
 
     .content.collapsed {
@@ -184,7 +185,8 @@ main {
 
 .breadcrumb-container {
     position: sticky;
-    top: 0;
+    /* Stick below the header */
+    top: 59px;
     z-index: 900;
     background-color: #ffffff;
 }


### PR DESCRIPTION
## Summary
- allow sticky elements by removing overflow restriction on main content wrapper
- keep breadcrumb below header while scrolling

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689ec1732e1483229586786cb08fd0b1