### PR TITLE
style: unify allocation forms with company config layout

### DIFF
--- a/AssetManagement/Client/Pages/AppPages/Allocation/AllocationLanding.razor
+++ b/AssetManagement/Client/Pages/AppPages/Allocation/AllocationLanding.razor
@@ -11,12 +11,10 @@
 @layout NoLayout
 @attribute [AllowAnonymous]
 
-<div>
-    <div class="card">
-        <div class="card-header bg-secondary text-center">
-            @Title
-        </div>
+<div class="container mt-4">
+    <div class="card shadow-sm">
         <div class="card-body">
+            <h5 class="mb-4 text-center">@Title</h5>
             @if (model == null && !TaskCompleted)
             {
                 <div class="loader-container mt-4">

--- a/AssetManagement/Client/Pages/AppPages/Allocation/UnAllocate.razor
+++ b/AssetManagement/Client/Pages/AppPages/Allocation/UnAllocate.razor
@@ -8,12 +8,10 @@
 @inject NavigationManager NavigationManager
 @attribute [Authorize]
 
-<div>
-    <div class="card">
-        <div class="card-header bg-secondary text-center">
-            @Title
-        </div>
+<div class="container mt-4">
+    <div class="card shadow-sm">
         <div class="card-body">
+            <h5 class="mb-4 text-center">@Title</h5>
             @if (model == null)
             {
                 <div class="loader-container mt-4">


### PR DESCRIPTION
## Summary
- Apply company-config container and card styling to allocation landing page
- Apply company-config container and card styling to unallocation page

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689ec8a7a3d08322ad2a0ca94ffc7feb