### PR TITLE
Fix user profile image upload and defaults

### DIFF
--- a/AssetManagement/Client/Pages/Auth Pages/UserProfile.razor
+++ b/AssetManagement/Client/Pages/Auth Pages/UserProfile.razor
@@ -335,12 +335,12 @@
             }
             else
             {
-                BgimageDataUrl = "assets/img/cover.jpg";
+                BgimageDataUrl = "/assets/img/cover.jpg";
             }
         }
         else
         {
-            imageDataUrl = "/assets/ima/no-profile.png";
+            imageDataUrl = "/assets/img/no-profile.png";
             BgimageDataUrl = "/assets/img/cover.jpg";
         }
     }
@@ -459,7 +459,7 @@
         if (file != null)
         {
             var buffer = new byte[file.Size];
-            await file.OpenReadStream().ReadAsync(buffer);
+            await file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024).ReadAsync(buffer);
 
 
             // Store the image data in the model
@@ -493,12 +493,13 @@
         if (file != null)
         {
             var buffer = new byte[file.Size];
-            await file.OpenReadStream().ReadAsync(buffer);
+            await file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024).ReadAsync(buffer);
 
 
             // Convert the image to a data URL for preview
 
             profilePic.BackgroundImage = buffer;
+            profilePic.Email = userInfo.Email;
 
             // Convert the image to a data URL for preview
             BgimageDataUrl = $"data:image/png;base64,{Convert.ToBase64String(buffer)}";
@@ -527,6 +528,7 @@
         profilePic.removePp = true;
         profilePic.removebg = false;
         profilePic.ProfileImage = null;
+        profilePic.Email = userInfo.Email;
         var responce = await client.DeleteProfBgPic(profilePic);
 
 
@@ -535,10 +537,11 @@
 
     private async void RemoveBgImage()
     {
-        BgimageDataUrl = "assets/img/cover.jpg";
+        BgimageDataUrl = "/assets/img/cover.jpg";
         profilePic.removePp = false;
         profilePic.removebg = true;
         profilePic.BackgroundImage = null;
+        profilePic.Email = userInfo.Email;
 
         var responce = await client.DeleteProfBgPic(profilePic);
 


### PR DESCRIPTION
## Summary
- allow larger profile and background image uploads
- default to bundled images when profile or cover photos are missing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a344341bd48322b3b5bbdbff2f1df4