### PR TITLE
Add migration for user profile picture table

### DIFF
--- a/AssetManagement.DataContext/AppDbContext.cs
+++ b/AssetManagement.DataContext/AppDbContext.cs
@@ -11,10 +11,10 @@ namespace AssetManagement.DataContext
 {
     public class AppDbContext : DbContext
     {
-        public AppDbContext(DbContextOptions<AppDbContext> options, bool ensureCreated = true) : base(options) 
+        public AppDbContext(DbContextOptions<AppDbContext> options, bool ensureCreated = true) : base(options)
         {
             if (ensureCreated)
-                Database.EnsureCreated();
+                Database.Migrate();
         }
         public DbSet<UserProfilePicUpld> UserProfilePicUpld { get; set; }
         public DbSet<Company> Company { get; set; }

--- a/AssetManagement.DataContext/Migrations/20240527120000_AddUserProfilePicUpld.cs
+++ b/AssetManagement.DataContext/Migrations/20240527120000_AddUserProfilePicUpld.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AssetManagement.DataContext.Migrations
+{
+    public partial class AddUserProfilePicUpld : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserProfilePicUpld",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Email = table.Column<string>(type: "TEXT", nullable: false),
+                    ProfileImage = table.Column<byte[]>(type: "BLOB", nullable: true),
+                    BackgroundImage = table.Column<byte[]>(type: "BLOB", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserProfilePicUpld", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserProfilePicUpld");
+        }
+    }
+}

--- a/AssetManagement.DataContext/Migrations/AppDbContextModelSnapshot.cs
+++ b/AssetManagement.DataContext/Migrations/AppDbContextModelSnapshot.cs
@@ -36,6 +36,27 @@ namespace AssetManagement.DataContext.Migrations
                     b.ToTable("Details");
                 });
 
+            modelBuilder.Entity("AssetManagement.Dto.UserProfilePicUpld", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<byte[]>("BackgroundImage")
+                        .HasColumnType("BLOB");
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasColumnType("TEXT");
+
+                    b.Property<byte[]>("ProfileImage")
+                        .HasColumnType("BLOB");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("UserProfilePicUpld");
+                });
+
             modelBuilder.Entity("AssetManagement.Dto.Models.Allocation", b =>
                 {
                     b.Property<int>("Id")


### PR DESCRIPTION
## Summary
- ensure migrations are applied at startup instead of relying on EnsureCreated
- add migration to create `UserProfilePicUpld` table
- update EF Core model snapshot for new entity

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a347378ed88322b2f74a288c361d75