### PR TITLE
Ignore pending EF Core model changes warning

### DIFF
--- a/AssetManagement.DataContext/AppDbContext.cs
+++ b/AssetManagement.DataContext/AppDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,6 +43,11 @@ namespace AssetManagement.DataContext
             modelBuilder.Entity<Asset>().Ignore(o => o.EmployeeEmail);
             modelBuilder.Entity<EmployeeOnboardingDto>().Ignore(o => o.ManagerMobile);
             base.OnModelCreating(modelBuilder);
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
         }
 
     }


### PR DESCRIPTION
## Summary
- suppress PendingModelChangesWarning to avoid startup exception when updating database

## Testing
- `dotnet build AssetManagement.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a35ad6b8b08322a7ef79904e7b5a7b