### PR TITLE
Fix profile profile page tab and edit mode toggles

### DIFF
--- a/AssetManagement/Client/Pages/Auth Pages/UserProfile.razor
+++ b/AssetManagement/Client/Pages/Auth Pages/UserProfile.razor
@@ -24,7 +24,7 @@
             <img src="@BgimageDataUrl" alt="User Background Image" class="img-fluid" style="height: 46vh; object-fit: cover;">
             <div class="change-cover">
                 <div class="dropdown">
-                    <a class="drp-icon dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="drp-icon dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <i class="icon feather icon-camera"></i>
                     </a>
                     <div class="dropdown-menu">
@@ -46,7 +46,7 @@
                 <div class="col-md-4 text-center mt-n5">
                     <div class="change-profile text-center">
                         <div class="dropdown">
-                            <a class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <a class="dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <div class="profile-dp">
                                     <img id="imgPreview" class="img-radius img-fluid" src="@imageDataUrl" alt="User image" style="height: 15vh; width: 15vh; object-fit: cover;" />
                                     <div class="">
@@ -88,12 +88,12 @@
                     </div>
                     <ul class="nav nav-tabs profile-tabs nav-fill" id="myTab" role="tablist">
                         <li class="nav-item">
-                            <a class="nav-link active" id="profile-tab" data-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">
+                            <a class="nav-link active" id="profile-tab" data-bs-toggle="tab" href="#profile" role="tab" aria-controls="profile" aria-selected="false">
                                 <i class="feather icon-user mr-2"></i>Profile
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" id="contact-tab" data-toggle="tab" href="#chnagepwd" role="tab" aria-controls="contact" aria-selected="false">
+                            <a class="nav-link" id="contact-tab" data-bs-toggle="tab" href="#chnagepwd" role="tab" aria-controls="contact" aria-selected="false">
                                 <i class="feather icon-phone mr-2"></i>Change Password
                             </a>
                         </li>
@@ -111,7 +111,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="mb-3">Personal Information</h5>
-                        <button type="button" class="btn btn-primary btn-sm rounded" data-toggle="collapse" data-target=".pro-det-edit" aria-expanded="false">
+                        <button type="button" class="btn btn-primary btn-sm rounded" data-bs-toggle="collapse" data-bs-target=".pro-det-edit" aria-expanded="false">
                             <i class="feather icon-edit"></i>
                         </button>
                     </div>
@@ -219,7 +219,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="mb-3">Change Password</h5>
-                        <button type="button" class="btn btn-primary btn-sm rounded" data-toggle="collapse" data-target=".pro-pwd-edit" aria-expanded="false">
+                        <button type="button" class="btn btn-primary btn-sm rounded" data-bs-toggle="collapse" data-bs-target=".pro-pwd-edit" aria-expanded="false">
                             <i class="feather icon-edit"></i>
                         </button>
                     </div>

--- a/AssetManagement/Client/Shared/LoginDisplay.razor
+++ b/AssetManagement/Client/Shared/LoginDisplay.razor
@@ -13,7 +13,7 @@
             <Authorized>
 
                 <div class="dropdown drp-user">
-                    <a class="dropdown-toggle" data-toggle="dropdown">
+                    <a class="dropdown-toggle" data-bs-toggle="dropdown">
                         @* <img src="assets/images/user/avatar-1.jpg" class="img-radius wid-40"
                              alt="User-Profile-Image"> *@
                         <div style="cursor:pointer" class="profile-image-circle">@context.User.Identity.Name.ToUpper().Substring(0, 1)</div>


### PR DESCRIPTION
## Summary
- Switch profile page dropdowns, tabs, and collapse buttons to Bootstrap 5 `data-bs-*` attributes to restore functionality
- Update login dropdown trigger for Bootstrap 5 compatibility

## Testing
- `dotnet build AssetManagement.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_b_68a3618a065883228de995140a4ab820