### PR TITLE
fix: secure onboarding retrieval with key

### DIFF
--- a/AssetManagement.Repositories/AppRepository.cs
+++ b/AssetManagement.Repositories/AppRepository.cs
@@ -445,24 +445,6 @@ namespace AssetManagement.Repositories
                 return null;
             }
         } 
-        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingById(int id)
-        {
-            try
-            {
-                EmployeeOnboardingDto result = null;
-
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-                result = await AppDbCxt.EmployeeOnboarding
-                        .FirstOrDefaultAsync(o => o.Id == id);
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                return null;
-            }
-        }
         public async Task<EmployeeOnboardingDto> UpsertConfirmOnboardingAsync(OnBoardingConfirmationDto data)
         {
             try
@@ -621,28 +603,6 @@ namespace AssetManagement.Repositories
             return result;
         }
 
-
-
-       public async Task<EmployeeOnboardingDto> GetEmployeeonboardingById(int id)
-                   
-        {
-            try
-            {
-                EmployeeOnboardingDto result = null;
-
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-                result = await AppDbCxt.EmployeeOnboarding
-                        .FirstOrDefaultAsync(o => o.Id == id);
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                return null;
-            }
-        }
-
         public async Task<ApiResponse<EmployeeOnboardingDto>> UpsertEmployeeOnboarding(EmployeeOnboardingDto data)
         {
             var result = new ApiResponse<EmployeeOnboardingDto>();
@@ -657,27 +617,26 @@ namespace AssetManagement.Repositories
                 }
                 else
                 {
-                    var Check = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.ExternalEmailId == data.ExternalEmailId);
-                    if (Check != null)
+                    var check = await AppDbCxt.EmployeeOnboarding
+                        .FirstOrDefaultAsync(o => o.ExternalEmailId.ToLower() == data.ExternalEmailId.ToLower());
+                    if (check != null)
                     {
                         result.IsSuccess = false;
                         result.Message = "Email already exist!";
                         return result;
                     }
-                    else
-                    {
-                        var timestamp = DateTime.Now;
-                        var key = $"{data.Id}-{data.ExternalEmailId}-{timestamp}".ComputeMd5Hash().ToLower();
-                        var returnUrl = $"{data.BaseUrl}/EmployeeOnBoarding/{key}";
-                        data.ReturnUrl = returnUrl;
-                        data.SecurityStamp = key;
-                        data.Date = DateTime.Now;
-                        AppDbCxt.EmployeeOnboarding.Add(data);
-                        await AppDbCxt.SaveChangesAsync();
-                        data.ManagerMobile = AppDbCxt.Employee.Where(o => o.EmailId == data.ReportingTo).Select(o => o.MobileNumber).FirstOrDefault();
-                        data.CompanyName = AppDbCxt.Company.Where(o => o.CompanyCode == data.CompanyCode).Select(o => o.Name).FirstOrDefault();
-                        result.Result = data;
-                    }
+
+                    var timestamp = DateTime.Now;
+                    var key = $"{data.Id}-{data.ExternalEmailId}-{timestamp}".ComputeMd5Hash().ToLower();
+                    var returnUrl = $"{data.BaseUrl}/EmployeeOnBoarding/{key}";
+                    data.ReturnUrl = returnUrl;
+                    data.SecurityStamp = key;
+                    data.Date = DateTime.Now;
+                    AppDbCxt.EmployeeOnboarding.Add(data);
+                    await AppDbCxt.SaveChangesAsync();
+                    data.ManagerMobile = AppDbCxt.Employee.Where(o => o.EmailId == data.ReportingTo).Select(o => o.MobileNumber).FirstOrDefault();
+                    data.CompanyName = AppDbCxt.Company.Where(o => o.CompanyCode == data.CompanyCode).Select(o => o.Name).FirstOrDefault();
+                    result.Result = data;
                 }
 
             }
@@ -698,7 +657,7 @@ namespace AssetManagement.Repositories
             var result = new ApiResponse<EmployeeOnboardingDto>();
             try
             {
-                var data = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.SecurityStamp == key);
+                var data = await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.SecurityStamp == key);
                 //var data = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.SecurityStamp == key && o.IsReplied == false);
                 if (data == null)
                 {
@@ -719,7 +678,7 @@ namespace AssetManagement.Repositories
             var result = new ApiResponse<EmployeeOnboardingDto>();
             try
             {
-                var data = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.SecurityStamp == key);
+                var data = await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.SecurityStamp == key);
                 if (data == null)
                 {
                     result.Message = "No Data Found in Database!";

--- a/AssetManagement.Repositories/EmployeeOnboardingRepository.cs
+++ b/AssetManagement.Repositories/EmployeeOnboardingRepository.cs
@@ -19,23 +19,11 @@ namespace AssetManagement.Repositories
             AppDbCxt = appContext;
         }
 
-        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingById(int id)
+        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingByKey(string key)
         {
             try
             {
-                return await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.Id == id);
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        public async Task<EmployeeOnboardingDto> GetEmployeeonboardingById(int id)
-        {
-            try
-            {
-                return await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.Id == id);
+                return await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.SecurityStamp == key);
             }
             catch (Exception)
             {
@@ -81,27 +69,26 @@ namespace AssetManagement.Repositories
                 }
                 else
                 {
-                    var check = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.ExternalEmailId == data.ExternalEmailId);
+                    var check = await AppDbCxt.EmployeeOnboarding
+                        .FirstOrDefaultAsync(o => o.ExternalEmailId.ToLower() == data.ExternalEmailId.ToLower());
                     if (check != null)
                     {
                         result.IsSuccess = false;
                         result.Message = "Email already exist!";
                         return result;
                     }
-                    else
-                    {
-                        var timestamp = DateTime.Now;
-                        var key = $"{data.Id}-{data.ExternalEmailId}-{timestamp}".ComputeMd5Hash().ToLower();
-                        var returnUrl = $"{data.BaseUrl}/EmployeeOnBoarding/{key}";
-                        data.ReturnUrl = returnUrl;
-                        data.SecurityStamp = key;
-                        data.Date = DateTime.Now;
-                        AppDbCxt.EmployeeOnboarding.Add(data);
-                        await AppDbCxt.SaveChangesAsync();
-                        data.ManagerMobile = AppDbCxt.Employee.Where(o => o.EmailId == data.ReportingTo).Select(o => o.MobileNumber).FirstOrDefault();
-                        data.CompanyName = AppDbCxt.Company.Where(o => o.CompanyCode == data.CompanyCode).Select(o => o.Name).FirstOrDefault();
-                        result.Result = data;
-                    }
+
+                    var timestamp = DateTime.Now;
+                    var key = $"{data.Id}-{data.ExternalEmailId}-{timestamp}".ComputeMd5Hash().ToLower();
+                    var returnUrl = $"{data.BaseUrl}/EmployeeOnBoarding/{key}";
+                    data.ReturnUrl = returnUrl;
+                    data.SecurityStamp = key;
+                    data.Date = DateTime.Now;
+                    AppDbCxt.EmployeeOnboarding.Add(data);
+                    await AppDbCxt.SaveChangesAsync();
+                    data.ManagerMobile = AppDbCxt.Employee.Where(o => o.EmailId == data.ReportingTo).Select(o => o.MobileNumber).FirstOrDefault();
+                    data.CompanyName = AppDbCxt.Company.Where(o => o.CompanyCode == data.CompanyCode).Select(o => o.Name).FirstOrDefault();
+                    result.Result = data;
                 }
             }
             catch (Exception ex)
@@ -121,7 +108,7 @@ namespace AssetManagement.Repositories
             var result = new ApiResponse<EmployeeOnboardingDto>();
             try
             {
-                var data = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.SecurityStamp == key);
+                var data = await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.SecurityStamp == key);
                 if (data == null)
                 {
                     result.Message = "You have already Updated your details";
@@ -137,12 +124,12 @@ namespace AssetManagement.Repositories
             return result;
         }
 
-        public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataByID(string key)
+        public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataById(int id)
         {
             var result = new ApiResponse<EmployeeOnboardingDto>();
             try
             {
-                var data = AppDbCxt.EmployeeOnboarding.FirstOrDefault(o => o.SecurityStamp == key);
+                var data = await AppDbCxt.EmployeeOnboarding.FirstOrDefaultAsync(o => o.Id == id);
                 if (data == null)
                 {
                     result.Message = "No Data Found in Database!";

--- a/AssetManagement.Repositories/IAppRepository.cs
+++ b/AssetManagement.Repositories/IAppRepository.cs
@@ -41,8 +41,6 @@ namespace AssetManagement.Repositories
         Task<Employee> GetEmployeeById(int id);
         Task<EmployeeFilesMapping> GetEmployeeFilesById(int id);
         Task<IEnumerable<EmployeeInsurance>> GetEmployeeInsuranceById(int id);
-        Task<EmployeeOnboardingDto> GetEmployeeOnboardingById(int id);
-        Task<EmployeeOnboardingDto> GetEmployeeonboardingById(int id);
         Task<ReportFilters> GetEmployeeReportFileters();
         Task<EmployeeSkills> GetEmployeeSkillsById(int id);
         Task<List<EmployeeSkillMapping>> GetEmployeeSkillsIDs(int employeeId);

--- a/AssetManagement.Repositories/IEmployeeOnboardingRepository.cs
+++ b/AssetManagement.Repositories/IEmployeeOnboardingRepository.cs
@@ -7,12 +7,11 @@ namespace AssetManagement.Repositories
 {
     public interface IEmployeeOnboardingRepository
     {
-        Task<EmployeeOnboardingDto> GetEmployeeOnboardingById(int id);
-        Task<EmployeeOnboardingDto> GetEmployeeonboardingById(int id);
+        Task<EmployeeOnboardingDto> GetEmployeeOnboardingByKey(string key);
         Task<EmployeeOnboardingDto> UpsertConfirmOnboardingAsync(OnBoardingConfirmationDto data);
         Task<ApiResponse<EmployeeOnboardingDto>> UpsertEmployeeOnboarding(EmployeeOnboardingDto data);
         Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataByKey(string key);
-        Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataByID(string key);
+        Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataById(int id);
         Task<EmployeeOnboardingDto> ShareFormWithOnboardeeViaEmail(int id);
         Task<ApiResponse<EmployeeFilesMapping>> UpsertEmployeeFilesAsync(EmployeeFilesMapping data);
         Task<EmployeeFilesMapping> GetEmployeeFilesById(int id);

--- a/AssetManagement/Client/Client/AppClient.cs
+++ b/AssetManagement/Client/Client/AppClient.cs
@@ -393,12 +393,12 @@ namespace AssetManagement.Client.Client
 
             return result;
         }  
-        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingById(int id)
+        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingByKey(string key)
         {
             EmployeeOnboardingDto result = null;
             try
             {
-                var res = await HttpClient.GetAsync($"api/EmployeeOnboarding/{id}");
+                var res = await HttpClient.GetAsync($"api/EmployeeOnboarding/{key}");
 
                 res.EnsureSuccessStatusCode();
 
@@ -546,13 +546,13 @@ namespace AssetManagement.Client.Client
             }
             return result;
         }
-        public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataById(string Key)
+        public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataById(int id)
         {
             var result = new ApiResponse<EmployeeOnboardingDto>();
             try
             {
-                var payload = new GenericApiRequest<string>() { Param = Key };
-                var responce = await HttpClient.PostAsJsonAsync<GenericApiRequest<string>>($"api/EmployeeOnboarding/ById", payload);
+                var payload = new GenericApiRequest<int>() { Param = id };
+                var responce = await HttpClient.PostAsJsonAsync<GenericApiRequest<int>>($"api/EmployeeOnboarding/ById", payload);
                 responce.EnsureSuccessStatusCode();
 
                 if (responce.IsSuccessStatusCode)

--- a/AssetManagement/Client/Pages/AppPages/Employees/EmployeeDataConfig.razor
+++ b/AssetManagement/Client/Pages/AppPages/Employees/EmployeeDataConfig.razor
@@ -1088,7 +1088,7 @@
         EmployeeInsurance.Add(new EmployeeInsurance());
         if (Key != null)
         {
-            var responce = await client.GetOnboardingDataById(Key);
+            var responce = await client.GetOnboardingDataByKey(Key);
             if (responce.IsSuccess)
             {
                 var data = responce.Result;

--- a/AssetManagement/Client/Pages/AppPages/Employees/EmployeeOnBoardingLanding.razor
+++ b/AssetManagement/Client/Pages/AppPages/Employees/EmployeeOnBoardingLanding.razor
@@ -1,4 +1,4 @@
-﻿@page "/EmployeeOnBoarding/{param}/{key}"
+﻿@page "/EmployeeOnBoarding/{param}/{Id:int}"
 @page "/EmployeeOnBoarding/{key}"
 
 @using AssetManagement.Client.Client;
@@ -742,7 +742,7 @@
         }
 
 
-        var responce = param == null ? await client.GetOnboardingDataByKey(key) : await client.GetOnboardingDataById(key);
+        var responce = param == null ? await client.GetOnboardingDataByKey(key) : await client.GetOnboardingDataById(Id);
         SkillOptions = new List<EmployeeSkills>(await client.GetAllSkill());
 
         if (responce.IsSuccess)
@@ -933,7 +933,7 @@
             }
 
 
-            var responce = param == null ? await client.GetOnboardingDataByKey(key) : await client.GetOnboardingDataById(key);
+            var responce = param == null ? await client.GetOnboardingDataByKey(key) : await client.GetOnboardingDataById(Id);
             SkillOptions = new List<EmployeeSkills>(await client.GetAllSkill());
 
             if (responce.IsSuccess)

--- a/AssetManagement/Client/Pages/AppPages/Employees/OnboardingconfirmationDetails.razor
+++ b/AssetManagement/Client/Pages/AppPages/Employees/OnboardingconfirmationDetails.razor
@@ -1,4 +1,4 @@
-﻿@page "/OnBoardingConfirmationDetails/{Id:int}"
+﻿@page "/OnBoardingConfirmationDetails/{Key}"
 @using AssetManagement.Client.Client
 @using AssetManagement.Dto.Models
 @using Microsoft.AspNetCore.Components.Forms
@@ -89,7 +89,7 @@
 
 @code {
     [Parameter]
-    public int Id { get; set; }
+    public string Key { get; set; }
 
     private bool Onload = true;
     private string JoinStatus;
@@ -111,7 +111,7 @@
             Onload = true;
 
 
-            EmployeeOnboarding = await client.GetEmployeeOnboardingById(Id);
+            EmployeeOnboarding = await client.GetEmployeeOnboardingByKey(Key);
             if (EmployeeOnboarding != null)
             {
                 model.Name = EmployeeOnboarding.Name;
@@ -189,7 +189,7 @@
 
 
 
-@* @page "/OnBoardingConfirmationDetails/{Id:int}" *@
+@* @page "/OnBoardingConfirmationDetails/{Key}" *@
 @* @using AssetManagement.Client.Client; *@
 @* @using AssetManagement.Client.Pages.AppPages.Employees.Component *@
 @* @using AssetManagement.Client.Shared.Popup *@
@@ -247,7 +247,7 @@
 
 @* @code { *@
 @*     [Parameter] *@
-@*     public int Id { get; set; } *@
+@*     public string Key { get; set; } *@
 @*     bool Onload = false; *@
 @*     private string JoinStatus { get; set; } = ""; *@
 @*     private DateTime? NextDateOfJoining { get; set; } *@

--- a/AssetManagement/Client/Pages/GridButton/EmployeeOnboardEditButton.razor
+++ b/AssetManagement/Client/Pages/GridButton/EmployeeOnboardEditButton.razor
@@ -18,6 +18,6 @@
 
     private void MyClickHandler(MouseEventArgs e)
     {
-        NavigationManager.NavigateTo($"/EmployeeOnBoarding/{"e&v"}/{Item.SecurityStamp}");
+        NavigationManager.NavigateTo($"/EmployeeOnBoarding/{"e&v"}/{Item.Id}");
     }
 }

--- a/AssetManagement/Server/Controllers/Api/EmployeeOnboardingController.cs
+++ b/AssetManagement/Server/Controllers/Api/EmployeeOnboardingController.cs
@@ -23,9 +23,9 @@ namespace AssetManagement.Server.Controllers.Api
             _env = env;
         }
 
-        [HttpGet("{id}")]
+        [HttpGet("{key}")]
         [AllowAnonymous]
-        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingById(int id) => await _repository.GetEmployeeOnboardingById(id);
+        public async Task<EmployeeOnboardingDto> GetEmployeeOnboardingByKey(string key) => await _repository.GetEmployeeOnboardingByKey(key);
 
         [HttpPost("Confirm")]
         [AllowAnonymous]
@@ -68,10 +68,7 @@ namespace AssetManagement.Server.Controllers.Api
         public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataByKey(GenericApiRequest<string> request) => await _repository.GetOnboardingDataByKey(request.Param);
 
         [HttpPost("ById")]
-        public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataById(GenericApiRequest<string> request) => await _repository.GetOnboardingDataByID(request.Param);
-
-        [HttpGet("form/{id}")]
-        public async Task<EmployeeOnboardingDto> GetEmployeeonboardingById(int id) => await _repository.GetEmployeeonboardingById(id);
+        public async Task<ApiResponse<EmployeeOnboardingDto>> GetOnboardingDataById(GenericApiRequest<int> request) => await _repository.GetOnboardingDataById(request.Param);
 
         [HttpPost("Files")]
         [AllowAnonymous]

--- a/AssetManagement/Server/Service/OnboardingConfirmation.cs
+++ b/AssetManagement/Server/Service/OnboardingConfirmation.cs
@@ -31,7 +31,7 @@ namespace AssetManagement.Server.Service
 
                     if (employee.Reference != "NA")
                     {
-                        var url = $"https://localhost:7053/OnBoardingConfirmationDetails/{employee.Id}";
+                        var url = $"https://localhost:7053/OnBoardingConfirmationDetails/{employee.SecurityStamp}";
                         var referName = employees.Where(o=>o.EmailId.ToLower() == employee.Reference.ToLower()).Select(o=>o.EmployeeName).FirstOrDefault();
                         string body = $"Hi {referName} ,<br/><br/>" +
                                       $"This is to kindly request your confirmation regarding the candidate <b>{employee.Name}</b>, whom you had referred for employment.<br/>" +


### PR DESCRIPTION
## Summary
- protect anonymous onboarding access by requiring a unique key instead of numeric IDs
- update repository, controller, client and confirmation page to use the security stamp
- include security stamp in email links for confirmation requests
- remove obsolete onboarding ID lookups and ensure email checks are case-insensitive

## Testing
- `dotnet build AssetManagement.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4257607a08322b79a1f6149c5dc59