### PR TITLE
Handle empty content type when reading API responses

### DIFF
--- a/AssetManagement/Client/Client/AppClient.cs
+++ b/AssetManagement/Client/Client/AppClient.cs
@@ -54,8 +54,7 @@ namespace AssetManagement.Client.Client
                 var res = await HttpClient.GetAsync($"api/App/GetProfilePicByEmail/{email}");
                 if (res.IsSuccessStatusCode)
                 {
-                    data = await res.Content.ReadFromJsonAsync<UserProfilePicUpld>();
-
+                    data = await ReadFromJsonAsyncSafe<UserProfilePicUpld>(res);
                 }
                 else
                 {

--- a/AssetManagement/Client/Client/BaseHttpClient.cs
+++ b/AssetManagement/Client/Client/BaseHttpClient.cs
@@ -1,4 +1,8 @@
-﻿namespace AssetManagement.Client.Client
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace AssetManagement.Client.Client
 {
     public class BaseHttpClient
     {
@@ -10,5 +14,27 @@
 
         public ILogger Logger { get; }
         public HttpClient HttpClient { get; }
+
+        protected async Task<T?> ReadFromJsonAsyncSafe<T>(HttpResponseMessage response)
+        {
+            if (response.Content == null)
+                return default;
+
+            if (response.Content.Headers?.ContentLength == 0)
+                return default;
+
+            if (response.Content.Headers?.ContentType == null)
+            {
+                var raw = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(raw))
+                    return default;
+                return JsonSerializer.Deserialize<T>(raw, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+
+            return await response.Content.ReadFromJsonAsync<T>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Avoid NotSupportedException when API responses have no Content-Type header by adding a safe JSON reader.
- Use the safe reader in profile picture fetching logic to gracefully handle empty responses.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b19511301083228768812939c2f6b0