### PR TITLE
perf: parallelize employee config data loading

### DIFF
--- a/AssetManagement/Client/Pages/AppPages/Employees/EmployeeDataConfig.razor
+++ b/AssetManagement/Client/Pages/AppPages/Employees/EmployeeDataConfig.razor
@@ -1187,13 +1187,16 @@ protected override async Task OnInitializedAsync()
     // ===== ID-DRIVEN PATH =====
     else if (Id > 0)
     {
-        // fetch core model first (unlocks dependent calls)
-        model = await client.GetEmployeeById(Id);
+        // start all independent calls immediately
+        var modelTask      = client.GetEmployeeById(Id);
+        var insuranceTask  = client.GetEmployeeInsuranceById(Id);
+        var skillIdsTask   = client.GetEmployeeSkillsIDs(Id);
+        var filesTask      = GetEmployeeFiles(Id);
 
-        // launch dependent calls in parallel
-        var insuranceTask   = client.GetEmployeeInsuranceById(Id);
-        var skillIdsTask    = client.GetEmployeeSkillsIDs(Id);
-        var filesTask       = GetEmployeeFiles(Id);
+        // fetch core model first (unlocks dependent calls)
+        model = await modelTask;
+
+        // dependent calls
         var searchPinTask   = SeachPin(); // uses model.VendorPincode
 
         Task sharepointTask = Task.CompletedTask;


### PR DESCRIPTION
## Summary
- parallelize data fetching on EmployeeConfig form to cut page load time

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b1959046a08322865939b4e8e00a16