### PR TITLE
Add Microsoft SSO login with default User role

### DIFF
--- a/AssetManagement/Client/Pages/Auth Pages/Login.razor
+++ b/AssetManagement/Client/Pages/Auth Pages/Login.razor
@@ -44,6 +44,11 @@
                 <p class="text-danger mt-2">@error</p>
             </EditForm>
 
+            <!-- Microsoft SSO Button -->
+            <div class="mt-3">
+                <button type="button" class="btn btn-outline-secondary w-100" @onclick="MicrosoftLogin">Sign in with Microsoft</button>
+            </div>
+
             <!-- Forgot Password and Signup Links -->
             <div class="text-center mt-3">
                 <p class="mb-1">
@@ -77,6 +82,11 @@
         {
             error = ex.Message;
         }
+    }
+
+    private void MicrosoftLogin()
+    {
+        navigationManager.NavigateTo("api/Authorize/MicrosoftLogin", true);
     }
 
     protected override async Task OnInitializedAsync()

--- a/AssetManagement/Server/AssetManagement.Server.csproj
+++ b/AssetManagement/Server/AssetManagement.Server.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="9.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.2.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
     <PackageReference Include="Microsoft.Graph" Version="4.54.0" />

--- a/AssetManagement/Server/Controllers/Api/AuthorizeController.cs
+++ b/AssetManagement/Server/Controllers/Api/AuthorizeController.cs
@@ -67,6 +67,64 @@ namespace AssetManagement.Server.Controllers.Api
             return Ok();
         }
 
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult MicrosoftLogin(string returnUrl = "/")
+        {
+            var redirectUrl = Url.Action(nameof(MicrosoftResponse), new { ReturnUrl = returnUrl });
+            var properties = _signInManager.ConfigureExternalAuthenticationProperties("Microsoft", redirectUrl);
+            return Challenge(properties, "Microsoft");
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public async Task<IActionResult> MicrosoftResponse(string returnUrl = "/")
+        {
+            var info = await _signInManager.GetExternalLoginInfoAsync();
+            if (info == null)
+            {
+                return Redirect("/login");
+            }
+
+            var signInResult = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, false);
+            if (signInResult.Succeeded)
+            {
+                return LocalRedirect(returnUrl);
+            }
+
+            var email = info.Principal.FindFirstValue(ClaimTypes.Email);
+            if (string.IsNullOrEmpty(email))
+            {
+                return BadRequest("Email not provided by external provider.");
+            }
+
+            var user = new ApplicationUser
+            {
+                UserName = email,
+                Email = email,
+                IsActive = true
+            };
+
+            var createResult = await _userManager.CreateAsync(user);
+            if (!createResult.Succeeded)
+            {
+                return BadRequest(createResult.Errors.FirstOrDefault()?.Description);
+            }
+
+            await _userManager.AddLoginAsync(user, info);
+
+            var role = await _roleManager.FindByNameAsync("User");
+            if (role == null)
+            {
+                role = new ApplicationRole { Name = "User" };
+                await _roleManager.CreateAsync(role);
+            }
+            await _userManager.AddToRoleAsync(user, "User");
+
+            await _signInManager.SignInAsync(user, false);
+
+            return LocalRedirect(returnUrl);
+        }
 
         [HttpPost]
         public async Task<IActionResult> Register(RegisterParameters parameters)

--- a/AssetManagement/Server/Program.cs
+++ b/AssetManagement/Server/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
 using AssetManagement.Server.Service;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -92,6 +93,15 @@ else
 builder.Services.AddIdentity<ApplicationUser, ApplicationRole>()
     .AddEntityFrameworkStores<AuthDbContext>()
     .AddDefaultTokenProviders();
+
+// Add Microsoft authentication for SSO
+builder.Services.AddAuthentication()
+    .AddMicrosoftAccount(options =>
+    {
+        options.ClientId = config["Authentication:Microsoft:ClientId"];
+        options.ClientSecret = config["Authentication:Microsoft:ClientSecret"];
+        options.SaveTokens = true;
+    });
 
 // Configure Identity options
 builder.Services.Configure<IdentityOptions>(options =>

--- a/AssetManagement/Server/appsettings.Development.json
+++ b/AssetManagement/Server/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Authentication": {
+    "Microsoft": {
+      "ClientId": "Your-Microsoft-Client-Id",
+      "ClientSecret": "Your-Microsoft-Client-Secret"
+    }
   }
 }

--- a/AssetManagement/Server/appsettings.json
+++ b/AssetManagement/Server/appsettings.json
@@ -86,6 +86,13 @@
     "TenantId": "cf92019c-152d-42f6-bbcc-0cf96e6b0108"
   },
 
+  "Authentication": {
+    "Microsoft": {
+      "ClientId": "Your-Microsoft-Client-Id",
+      "ClientSecret": "Your-Microsoft-Client-Secret"
+    }
+  },
+
   //White Listing Url/IPs
   "Cors": {
     "AllowedOrigins": [


### PR DESCRIPTION
## Summary
- configure Microsoft Account authentication for SSO
- add endpoints that create SSO users with default `User` role
- expose Microsoft login button in the client UI

## Testing
- `dotnet build AssetManagement.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b1d4b8992083229c71842b2b9a2ebf